### PR TITLE
`nanoscope` start and stop tracing functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 build/
 .gradle/
+out/

--- a/src/main/java/com/uber/nanoscope/Adb.kt
+++ b/src/main/java/com/uber/nanoscope/Adb.kt
@@ -1,0 +1,43 @@
+package com.uber.nanoscope
+
+class Adb {
+
+    companion object {
+
+        fun getForegroundPackage(): String {
+            return "dumpsys activity activities"
+                    .adbShell()
+                    .inputStream
+                    .bufferedReader()
+                    .useLines { lines ->
+                        val line = lines.first { it.contains("mFocusedActivity") }.trim()
+                        val component = line.split(' ')[3]
+                        val packageName = component.split('/')[0]
+                        packageName
+                    }
+        }
+
+        fun setSystemProperty(name: String, value: String): Int {
+            return "setprop $name $value".adbShell().waitFor()
+        }
+
+        fun pullFile(remotePath: String, localPath: String): Int {
+            val process = "adb pull $remotePath $localPath".run()
+            process.inputStream.bufferedReader().forEachLine {  }
+            return process.waitFor()
+        }
+
+        fun fileExists(path: String): Boolean {
+            val output = "[ ! -e \"$path\" ]; echo $?".adbShell().inputStream.bufferedReader().readText().trim()
+            return output == "1"
+        }
+    }
+}
+
+private fun String.adbShell(): Process {
+    return "adb shell $this".run()
+}
+
+private fun String.run(): Process {
+    return Runtime.getRuntime().exec(this)
+}

--- a/src/main/java/com/uber/nanoscope/Main.kt
+++ b/src/main/java/com/uber/nanoscope/Main.kt
@@ -29,7 +29,14 @@ enum class Subcommand(
 class StartHandler(private val args: List<String>): Runnable {
 
     override fun run() {
-        println("start called: $args")
+        val trace = Nanoscope.startTracing()
+        println("Tracing... (Press ENTER to stop)")
+        while (true) {
+            if (System.`in`.read() == 10) {
+                break
+            }
+        }
+        trace.stop()
     }
 }
 

--- a/src/main/java/com/uber/nanoscope/Nanoscope.kt
+++ b/src/main/java/com/uber/nanoscope/Nanoscope.kt
@@ -1,0 +1,51 @@
+package com.uber.nanoscope
+
+import java.io.File
+
+class Nanoscope {
+
+    class Trace(
+            private val packageName: String,
+            private val filename: String) {
+
+        init {
+            Adb.setSystemProperty("dev.nanoscope", "$packageName:$filename")
+        }
+
+        fun stop() {
+            println("Flushing trace data... (Do not close app)")
+            Adb.setSystemProperty("dev.nanoscope", "\'\'")
+            val remotePath = "/data/data/$packageName/files/$filename"
+            while (!Adb.fileExists(remotePath)) {
+                Thread.sleep(500)
+            }
+
+            val localPath = File.createTempFile("nanoscope", ".trace").absolutePath
+            println("Pulling trace file... ($localPath)")
+            Adb.pullFile(remotePath, localPath)
+
+            val htmlPath = File.createTempFile("nanoscope", ".html").absolutePath
+            println("Building HTML... ($htmlPath)")
+            val html = buildHtml(localPath)
+            File(htmlPath).writeText(html)
+
+            println("Opening HTML...")
+            Runtime.getRuntime().exec("open $htmlPath")
+        }
+
+        private fun buildHtml(traceFilePath: String): String {
+            val traceDataString = File(traceFilePath).readText()
+            val html = javaClass.classLoader.getResourceAsStream("index.html").bufferedReader().readText()
+            return html.replaceFirst("TRACE_DATA_PLACEHOLDER", traceDataString)
+        }
+    }
+
+    companion object {
+
+        fun startTracing(): Trace {
+            val filename = "out.txt"
+            val foregroundPackage = Adb.getForegroundPackage()
+            return Trace(foregroundPackage, filename)
+        }
+    }
+}

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -251,6 +251,7 @@
         <canvas class="minimapCanvas" id="minimapCanvas"></canvas>
     </div>
 </div>
+<script type="text/plain" id="tracedata">TRACE_DATA_PLACEHOLDER</script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.4.0/gl-matrix-min.js"></script>
 
 <script>
@@ -1360,31 +1361,20 @@
             }
         }
 
+        loadEmbeddedData() {
+            let traceDataString = document.getElementById("tracedata").innerText;
+            if (traceDataString === "TRACE_DATA_PLACEHOLDER") {
+                return;
+            }
+            let traceDataBytes = new TextEncoder().encode(traceDataString);
+            this._loadBytes(traceDataBytes)
+        }
+
         onFileChange(file) {
-            this.canvasTraceRenderer.clear();
             let fileReader = new FileReader();
             fileReader.onload = e => {
                 let bytes = new Uint8Array(e.target.result);
-                let traceDataLoader = new TraceDataProcessor(bytes);
-                let methodRegistry = new MethodRegistry();
-                traceDataLoader.onPush = call => {
-                    methodRegistry.pushCall(call);
-                };
-                traceDataLoader.onPop = call => {
-                    this.canvasTraceRenderer.addCall(call);
-                    methodRegistry.popCall(call);
-                };
-                traceDataLoader.onProgress = this.loadingController.onProgress.bind(this.loadingController);
-                traceDataLoader.onDone = () => {
-                    this.searchController.setMethodRegistry(methodRegistry);
-                    this.minimapRenderer.setMethodRegistry(methodRegistry);
-                    this.detailsController.setMethodRegistry(methodRegistry);
-                    this.canvasTraceRenderer.focusOnRegistry(methodRegistry);
-                    this.loadingController.onDone();
-                    this._refreshCanvas();
-                };
-                this.loadingController.onStart(bytes.length);
-                traceDataLoader.load();
+                this._loadBytes(bytes)
             };
             fileReader.readAsArrayBuffer(file);
         }
@@ -1425,6 +1415,30 @@
             return false;
         }
 
+        _loadBytes(bytes) {
+            this.canvasTraceRenderer.clear();
+            let traceDataLoader = new TraceDataProcessor(bytes);
+            let methodRegistry = new MethodRegistry();
+            traceDataLoader.onPush = call => {
+                methodRegistry.pushCall(call);
+            };
+            traceDataLoader.onPop = call => {
+                this.canvasTraceRenderer.addCall(call);
+                methodRegistry.popCall(call);
+            };
+            traceDataLoader.onProgress = this.loadingController.onProgress.bind(this.loadingController);
+            traceDataLoader.onDone = () => {
+                this.searchController.setMethodRegistry(methodRegistry);
+                this.minimapRenderer.setMethodRegistry(methodRegistry);
+                this.detailsController.setMethodRegistry(methodRegistry);
+                this.canvasTraceRenderer.focusOnRegistry(methodRegistry);
+                this.loadingController.onDone();
+                this._refreshCanvas();
+            };
+            this.loadingController.onStart(bytes.length);
+            traceDataLoader.load();
+        }
+
         _focusCall(call) {
             this.canvasTraceRenderer.focus(call);
         }
@@ -1456,6 +1470,8 @@
     }
 
     resizeCanvas();
+
+    controller.loadEmbeddedData();
 
     document.getElementById('file').addEventListener('change', event => {
         let file = event.target.files[0];


### PR DESCRIPTION
Add trace start and stop functionality to `nanoscope` command:

```bash
./build/install/nanoscope/bin/nanoscope start
Tracing... (Press ENTER to stop)

Flushing trace data... (Do not close app)
Pulling trace file... (/var/folders/hj/v8lvgzpx7hs2b5x4_rd25f3r0000gn/T/nanoscope3206002395150556236.trace)
Building HTML... (/var/folders/hj/v8lvgzpx7hs2b5x4_rd25f3r0000gn/T/nanoscope4231421996513981920.html)
Opening HTML...
```