### PR TITLE
Display method call metadata below short method name

### DIFF
--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -310,6 +310,7 @@
             this.charZero = '0'.charCodeAt(0);
             this.charColon = ':'.charCodeAt(0);
             this.charNewline = '\n'.charCodeAt(0);
+            this.charMetaDataDelimiter = '#'.charCodeAt(0);
             this.charPeriod = '.'.charCodeAt(0);
             this.charLeftParen = '('.charCodeAt(0);
 
@@ -375,9 +376,10 @@
                 return;
             }
             this.timestamp = loadedTimestamp;
-            let names = this.loadName();
-            let name = names[0];
-            let shortName = names[1];
+            let namesAndMeta = this.loadNameAndMeta();
+            let name = namesAndMeta[0];
+            let shortName = namesAndMeta[1];
+            let meta = namesAndMeta[2];
             if (this.firstTimestamp === -1) {
                 this.firstTimestamp = this.timestamp;
             }
@@ -388,7 +390,7 @@
                 }
             } else {
                 let stackDepth = this.callStack.length + 1;
-                let call = new TraceCall(name, shortName, stackDepth, this.timestamp);
+                let call = new TraceCall(name, shortName, meta, stackDepth, this.timestamp);
                 this.callStack.push(call);
                 this.onPush(call);
             }
@@ -416,13 +418,13 @@
             return timestamp;
         }
 
-        loadName() {
+        loadNameAndMeta() {
             let name = "";
             let shortName = "";
             let next = this.next();
             let index = 0;
             let periods = [];
-            while (!next.done && next.value !== this.charNewline) {
+            while (!next.done && next.value !== this.charNewline && next.value !== this.charMetaDataDelimiter) {
                 if (!shortName) {
                     if (next.value === this.charPeriod) {
                         if (periods.size < 2) {
@@ -439,7 +441,15 @@
                 next = this.next();
                 index++;
             }
-            return [name, shortName];
+            let meta = "";
+            if (next.value === this.charMetaDataDelimiter) {
+                next = this.next();
+            }
+            while (!next.done && next.value !== this.charNewline) {
+                meta += String.fromCharCode(next.value);
+                next = this.next();
+            }
+            return [name, shortName, meta];
         }
     }
 
@@ -486,9 +496,10 @@
     // Represents a single invocation of a method.
     class TraceCall {
 
-        constructor(name, shortName, stackDepth, start) {
+        constructor(name, shortName, meta, stackDepth, start) {
             this.name = name;
             this.shortName = shortName;
+            this.meta = meta;
             this.stackDepth = stackDepth;
             this.start = start;
             this.end = null;
@@ -804,7 +815,14 @@
 
         selectCall(call) {
             this.selectedCall = call;
-            this.nameEl.innerText = call.shortName;
+            if (call.meta !== "") {
+                // If the meta descriptor has a slash in it we take all the content after the slash.
+                let metaParts = call.meta.split('/');
+                let metaShort = metaParts[metaParts.length -1];
+                this.nameEl.innerHTML = call.shortName + "</br><i>" + metaShort + "</i>";
+            } else {
+                this.nameEl.innerText = call.shortName;
+            }
 
             this.el.style.display = 'inline';
 


### PR DESCRIPTION
Display the metadata in italics one line below the method name if it exists. For now we assume that the format of the metadata will be a descriptor string. If we support different types of metadata in the future we will need to change this assumption.

<img width="377" alt="screen shot 2018-03-08 at 4 14 16 am" src="https://user-images.githubusercontent.com/549900/37150656-5a19e0ae-2287-11e8-8e30-377b4cf663f3.png">
