### PR TITLE
Root ADB before executing any command

### DIFF
--- a/src/main/java/com/uber/nanoscope/Adb.kt
+++ b/src/main/java/com/uber/nanoscope/Adb.kt
@@ -31,6 +31,10 @@ class Adb {
             val output = "[ ! -e \"$path\" ]; echo $?".adbShell().inputStream.bufferedReader().readText().trim()
             return output == "1"
         }
+
+        fun root() {
+            "adb root".run().waitFor()
+        }
     }
 }
 

--- a/src/main/java/com/uber/nanoscope/Nanoscope.kt
+++ b/src/main/java/com/uber/nanoscope/Nanoscope.kt
@@ -53,12 +53,14 @@ class Nanoscope {
         private val configDir = File(homeDir, ".nanoscope")
 
         fun startTracing(): Trace {
+            Adb.root()
             val filename = "out.txt"
             val foregroundPackage = Adb.getForegroundPackage()
             return Trace(foregroundPackage, filename)
         }
 
         fun flashDevice(romUrl: String) {
+            Adb.root()
             val md5 = MessageDigest.getInstance("MD5").digest(romUrl.toByteArray())
             val key = Base64.encode(md5)
             val outDir = File(configDir, "roms/$key")


### PR DESCRIPTION
The device may not be rooted so ensure ADB root before executing any commands.