### PR TITLE
Don't allow the user to zoom out farther than the starting width

### DIFF
--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -625,10 +625,17 @@
 
             this.inverse = mat3.create();
             this.viewport = new Rect(0, 0, 0, 0);
+            this.minXScale = 0;
         }
 
         applyTo(context) {
             context.setTransform(this.matrix[0], this.matrix[1], this.matrix[3], this.matrix[4], this.matrix[6], this.matrix[7]);
+        }
+
+        setMaxZoomFromModelWidth(duration) {
+            // The screen content should never take up a tiny portion of the screen. The screen
+            // looks silly when this happens.
+            this.minXScale = this.screenViewport.width / duration / (1 + 2 * THEME.MARGIN_AROUND_METHODS_AT_START);
         }
 
         setScreenViewport(screenViewport) {
@@ -689,6 +696,7 @@
             let originalModelPoint = this.toModelPosition(originalScreenPoint);
             scale = Math.sign(scale) * Math.min(K, Math.abs(scale)) / K + 1;
             mat3.scale(this.matrix, this.matrix, vec2.fromValues(scale, 1));
+            this.matrix[0] = Math.max(this.minXScale, this.matrix[0]);
             let newScreenPoint = this.toScreenPosition(originalModelPoint);
             let offsetX = originalScreenPoint[0] - newScreenPoint[0];
             let offsetY = originalScreenPoint[1] - newScreenPoint[1];
@@ -1058,6 +1066,11 @@
         focusOnRegistry(methodRegistry) {
             let duration = methodRegistry.maxTimestamp - methodRegistry.minTimestamp;
             this._focusWithMargin(methodRegistry.minTimestamp, 0, duration, THEME.MARGIN_AROUND_METHODS_AT_START);
+        }
+
+        setMaxZoomOut(methodRegistry) {
+            let duration = methodRegistry.maxTimestamp - methodRegistry.minTimestamp;
+            this.transform.setMaxZoomFromModelWidth(duration)
         }
 
         focus(call) {
@@ -1450,6 +1463,7 @@
                 this.minimapRenderer.setMethodRegistry(methodRegistry);
                 this.detailsController.setMethodRegistry(methodRegistry);
                 this.canvasTraceRenderer.focusOnRegistry(methodRegistry);
+                this.canvasTraceRenderer.setMaxZoomOut(methodRegistry);
                 this.loadingController.onDone();
                 this._refreshCanvas();
             };


### PR DESCRIPTION
There is no practical reason to zoom out farther than the starting zoom level. And it is easy to do by accident. When it happens, the tool feels a bit clumsy. So let's prevent this from happening.

![max_zoom_gif](https://user-images.githubusercontent.com/549900/37255291-75b0799a-2507-11e8-8ebc-b88516a42a0b.gif)