### PR TITLE
Add wrapper script to distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,4 +59,9 @@ task('deleteReleaseDrafts') {
     }
 }
 
+applicationDistribution.from("wrapper/nanoscopew") {
+    into("bin")
+    fileMode = 0755
+}
+
 applicationDefaultJvmArgs = ["-Xmx8g"]

--- a/wrapper/nanoscopew
+++ b/wrapper/nanoscopew
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+
+LOCAL_BIN=$(dirname "$PRG")
+WRAPPED_PRG="$LOCAL_BIN/nanoscope"
+CONFIG_DIR="$HOME/.nanoscope"
+ENV_FILE="$CONFIG_DIR/.env"
+PRE_FILE="$CONFIG_DIR/pre-command"
+
+if [ -f "$ENV_FILE" ]; then
+    export $(cat ${ENV_FILE} | grep -v ^# | xargs)
+fi
+
+if [ -f "$PRE_FILE" ]; then
+    ${PRE_FILE} $@
+fi
+
+exec ${WRAPPED_PRG} $@


### PR DESCRIPTION
In order to support internal customization of Nanoscope, we'll add a wrapper script that checks for the following:

* `$HOME/.nanoscope/.env` - If this exists, export the environment variables from the file before running the command.
* `$HOME/.nanoscope/pre-command` - If this exists, execute this script before running the command. Pass provided arguments to the `pre-command` script.